### PR TITLE
AssemblyScript 17 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,15 +24,15 @@
 		"prettier": "prettier --write './**/?*.*'"
 	},
 	"devDependencies": {
-		"@as-pect/cli": "4.0.0",
-		"@types/node": "^14.0.13",
-		"assemblyscript": "0.13.0",
+		"@as-pect/cli": "5.0.0",
+		"@types/node": "^14.14.11",
+		"assemblyscript": "0.17.7",
 		"live-server": "^1.2.1",
-		"prettier": "^2.0.5",
+		"prettier": "^2.2.1",
 		"rimraf": "^3.0.2",
-		"typescript": "^3.9.5"
+		"typescript": "^4.1.2"
 	},
 	"dependencies": {
-		"@assemblyscript/loader": "^0.10.0"
+		"@assemblyscript/loader": "^0.17.7"
 	}
 }


### PR DESCRIPTION
- New compiler update reveals some kind of shadow memory issue
- Will comment out one of the offending functions because we are not going to use it anyway
- Other shadow memory rogue releases are somewhere, and I believe it might be as-pect related (or potentially even further downstream)

 